### PR TITLE
Update heron.cgi to allow dxf upload

### DIFF
--- a/heron/cgi-bin/heron.cgi
+++ b/heron/cgi-bin/heron.cgi
@@ -341,7 +341,7 @@ def upload(params):
         # The config in the Heron client (Upload or Editor) should then have an entry like:
         # {name: 'ESRI Shapefile (1 laag, gezipped)', fileExt: '.zip', mimeType: 'text/plain', formatter: 'OpenLayers.Format.GeoJSON'}
         f, file_ext_in = os.path.splitext(file_item.filename.lower())
-        if file_ext_in == '.zip' or file_ext_in == '.gpkg' or file_ext_in == '.csv' or 'target_srs' in params:
+        if file_ext_in == '.zip' or file_ext_in == '.gpkg' or file_ext_in == '.csv' or file_ext_in == '.dxf' or 'target_srs' in params:
             # Convert with ogr2ogr
             work_dir = prepare_dir(suffix='_upwrk')
 


### PR DESCRIPTION
A small change to allow upload of dxf files.
Improves interoperability between the heron web viewer and most cad applications
Uploader config:

{name: 'DXF (EPSG:22195)', fileExt: '.dxf', mimeType: 'text/plain', formatter: 'OpenLayers.Format.GeoJSON', fileProjection: new OpenLayers.Projection('EPSG:22195')}
